### PR TITLE
Create master gruntfile to install dependencies and run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+dist
+
+# Javascript/Node stack ignores
+
+bower_components
+node_modules
+.lock-wscript
+
+# OSX ignores
+
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows ignores
+
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/

--- a/api/gruntfile.js
+++ b/api/gruntfile.js
@@ -1,0 +1,9 @@
+module.exports = function(grunt) {  
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+    });
+
+    // do nothing for now, just here so grunt-subgrunt can run npm install.
+
+    grunt.registerTask("default", [ ]);
+};

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,24 @@
+/**
+ * Created by Michael Dewberry on 9/12/2014.
+ *
+ */
+module.exports = function(grunt) {  
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+
+        subgrunt: {
+            options: {
+                "limit": 1 // CPU limit of one to force projects to be grunted in order
+            },
+            sway: {
+                "api": [ "default" ],
+                "ui": [ "default" ],
+                "test": [ "test_sway_ui", "test_sway_api" ]
+            }
+        },
+    });
+
+    grunt.loadNpmTasks("grunt-subgrunt");
+
+    grunt.registerTask("default", [ "subgrunt" ]);
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sway",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-subgrunt": "~0.4.1"
+  }
+}

--- a/test/gruntfile.js
+++ b/test/gruntfile.js
@@ -36,11 +36,27 @@ module.exports = function(grunt) {
                     output: 'outputdir'
                 }
             }
+        },
+        "bower-install-simple": {
+            options: {
+                color: true
+            },
+            "prod": {
+                options: {
+                    production: true
+                }
+            },
+            "dev": {
+                options: {
+                    production: false
+                }
+            }
         }
     });
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-nodeunit');
     grunt.loadNpmTasks('grunt-karma');
-    grunt.registerTask('test_sway_ui', ['karma']);
-    grunt.registerTask('test_sway_api', ['nodeunit']);
+    grunt.loadNpmTasks('grunt-bower-install-simple');
+    grunt.registerTask('test_sway_ui', ['bower-install-simple', 'karma']);
+    grunt.registerTask('test_sway_api', ['bower-install-simple', 'nodeunit']);
 };

--- a/test/package.json
+++ b/test/package.json
@@ -1,21 +1,22 @@
 {
-    "name": "sway-test",
-    "version": "0.1.0",
-    "devDependencies": {
-        "grunt": "~0.4.5",
-        "grunt-bower": "0.13.4",
-        "grunt-contrib-jshint": "~0.10.0",
-        "grunt-contrib-jasmine": "~0.7.0",
-        "grunt-contrib-nodeunit": "~0.4.1",
-        "grunt-contrib-watch": "~0.6.1",
-        "grunt-karma": "~0.8.3",
-        "karma": "~0.12.21",
-        "karma-jasmine": "~0.1.5",
-        "karma-phantomjs-launcher": "~0.1.4",
-        "karma-requirejs": "~0.2.2",
-        "karma-sinon": "~1.0.3",
-        "nodeunit": "~0.9.0",
-        "phantomjs": "~1.9.7",
-        "requirejs": "~2.1.14"
-    }
+  "name": "sway-test",
+  "version": "0.1.0",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-bower": "0.13.4",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-jasmine": "~0.7.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-karma": "~0.8.3",
+    "karma": "~0.12.21",
+    "karma-jasmine": "~0.1.5",
+    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-requirejs": "~0.2.2",
+    "karma-sinon": "~1.0.3",
+    "nodeunit": "~0.9.0",
+    "phantomjs": "~1.9.7",
+    "requirejs": "~2.1.14",
+    "grunt-bower-install-simple": "~1.0.0"
+  }
 }

--- a/ui/Gruntfile.js
+++ b/ui/Gruntfile.js
@@ -45,7 +45,23 @@ module.exports = function(grunt) {
                 }
             }
         },
-        clean: ["<%= pkg.name %>.concat.js", "<%= pkg.name %>.concat.css"]
+        clean: ["<%= pkg.name %>.concat.js", "<%= pkg.name %>.concat.css"],
+
+        "bower-install-simple": {
+            options: {
+                color: true
+            },
+            "prod": {
+                options: {
+                    production: true
+                }
+            },
+            "dev": {
+                options: {
+                    production: false
+                }
+            }
+        }
     });
 
     grunt.loadNpmTasks("grunt-contrib-concat");
@@ -53,7 +69,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks("grunt-contrib-cssmin");
     grunt.loadNpmTasks("grunt-contrib-htmlmin");
     grunt.loadNpmTasks("grunt-contrib-clean");
+    grunt.loadNpmTasks("grunt-bower-install-simple");
 
-    grunt.registerTask("default", ["concat", "uglify", "cssmin", "htmlmin", "clean"]);
+    grunt.registerTask("default", ["bower-install-simple", "concat", "uglify", "cssmin", "htmlmin", "clean"]);
 
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "sway",
-    "app": "ui",
-    "version": "0.0.1",
-
-    "devDependencies": {
-        "grunt": "~0.4.5",
-        "grunt-contrib-concat": "~0.5.0",
-        "grunt-contrib-uglify": "~0.5.0",
-        "grunt-contrib-clean": "~0.6.0",
-        "grunt-contrib-htmlmin": "~0.3.0",
-        "grunt-contrib-cssmin": "~0.10.0"
-    }
+  "name": "sway",
+  "app": "ui",
+  "version": "0.0.1",
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-contrib-concat": "~0.5.0",
+    "grunt-contrib-uglify": "~0.5.0",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-htmlmin": "~0.3.0",
+    "grunt-contrib-cssmin": "~0.10.0",
+    "grunt-bower-install-simple": "~1.0.0"
+  }
 }


### PR DESCRIPTION
Addresses issue #11.

Chose the simplest strategy that seemed like it would work. For the most part it does, run grunt in project root, all installed dependencies look good, UI tests succeed, but I get nine assertion failures in API tests. Cause is not immediately obvious to me.

Seven "cannot read property 'user-agent' of undefined" and two "cannot read property 'l' of undefined."

sway.server.test.js
✔ tests - Server_Exists
  ✔ 
  ✔ 
✖ tests - Server_createUser_ReturnsUser
  ✖ Cannot read property 'user-agent' of undefined
  TypeError: Cannot read property 'user-agent' of undefined
    at Object.module.exports.createUser (/Users/dewb/ah/sway/api/sway.auth.js:76:33)

...

sway.control.test.js
✔ tests - test_Control
  ✔ 
  ✔ 
✔ tests - control_send_reachesOSC
  ✔ 
✖ tests - test_Control_Submission_IsReturnedInDebug
  ✔ 
  ✖ Cannot read property 'l' of undefined
  TypeError: Cannot read property 'l' of undefined
    at Object.exports.tests.test_Control_Submission_IsReturnedInDebug (/Users/dewb/ah/sway/test/scripts/api/sway.control.test.js:59:40)
